### PR TITLE
Fix profile badge for GD 2.2081 / Geode 5.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-project(FakeGDMod VERSION 1.0.0)
-
-add_library(${PROJECT_NAME} SHARED
-    src/main.cpp
-    # Add any extra C++ source files here
-)
+project(FakeGDMod VERSION 1.1.0)
 
 if (NOT DEFINED ENV{GEODE_SDK})
     message(FATAL_ERROR "Unable to find Geode SDK! Please define GEODE_SDK environment variable to point to Geode")
@@ -18,5 +13,9 @@ else()
 endif()
 
 add_subdirectory($ENV{GEODE_SDK} ${CMAKE_CURRENT_BINARY_DIR}/geode)
+
+add_library(${PROJECT_NAME} SHARED
+    src/main.cpp
+)
 
 setup_geode_mod(${PROJECT_NAME})

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,15 @@
 # FakeGDMod Changelog
+
+## v1.1.0 (2026-03-25)
+- Geode 5.4.1 support
+- Geometry Dash 2.2081 support
+- Fix profile moderator badge rendering by using current sprite names
+- Anchor the profile badge to `ProfilePage::m_usernameLabel` for stable placement
+
 ## v1.0.1 (2025-01-08)
 - Geode v4.1.0 support
 - Geometry Dash 2.207 support
 - macOS support!
+
 ## v1.0.0 (2024-09-08)
 - Initial release

--- a/mod.json
+++ b/mod.json
@@ -1,32 +1,32 @@
 {
-	"geode": "4.1.2",
-	"gd": {
-		"win": "2.2074",
-		"android": "2.2074",
-		"mac": "2.2074",
-		"ios": "2.2074"
-	},
-	"id": "bitz.fakegdmod",
-	"tags": [
-		"joke",
-		"content"
-	],
-	"settings": {
-		"modType": {
-			"name": "Moderator Type",
-			"description": "you can choose 1 = Moderator, 2 = Elder Moderator, 3 = Leaderboard Moderator",
-			"type": "int",
-			"default": 1,
-			"min": 1,
-			"max": 3
-		}
-	},
-	"links": {
-		"source": "https://github.com/iArtie/FakeGDMod",
-		"community": "https://discord.gg/gXg8w4xJDA"
-	},
-	"name": "FakeGDMod",
-	"version": "v1.0.1",
-	"developer": "BitZ",
-	"description": "A cool mod that make you a fake moderator"
+    "geode": "5.4.1",
+    "gd": {
+        "win": "2.2081",
+        "android": "2.2081",
+        "mac": "2.2081",
+        "ios": "2.2081"
+    },
+    "id": "bitz.fakegdmod",
+    "tags": [
+        "joke",
+        "content"
+    ],
+    "settings": {
+        "modType": {
+            "name": "Moderator Type",
+            "description": "you can choose 1 = Moderator, 2 = Elder Moderator, 3 = Leaderboard Moderator",
+            "type": "int",
+            "default": 1,
+            "min": 1,
+            "max": 3
+        }
+    },
+    "links": {
+        "source": "https://github.com/iArtie/FakeGDMod",
+        "community": "https://discord.gg/gXg8w4xJDA"
+    },
+    "name": "FakeGDMod",
+    "version": "v1.1.0",
+    "developer": "BitZ",
+    "description": "A cool mod that make you a fake moderator"
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,172 +7,169 @@ using namespace geode::prelude;
 #include <Geode/modify/RateDemonLayer.hpp>
 #include <Geode/modify/LevelInfoLayer.hpp>
 
-template<typename Base, typename T>
+template <typename Base, typename T>
 inline bool instanceof(const T* ptr) {
-	return dynamic_cast<const Base*>(ptr) != nullptr;
+    return dynamic_cast<const Base*>(ptr) != nullptr;
 }
 
-class modCheck
-{
+static const char* getBadgeFrame(int type) {
+    switch (type) {
+        case 2: return "modBadge_02_001.png";
+        case 3: return "modBadge_03_001.png";
+        default: return "modBadge_01_001.png";
+    }
+}
+
+static CCSprite* createBadgeSprite(int type) {
+    if (auto badge = CCSprite::createWithSpriteFrameName(getBadgeFrame(type))) {
+        return badge;
+    }
+
+    // Keep compatibility with older sprite names just in case.
+    switch (type) {
+        case 2: return CCSprite::createWithSpriteFrameName("mod_badge_02_001.png");
+        case 3: return CCSprite::createWithSpriteFrameName("mod_badge_03_001.png");
+        default: return CCSprite::createWithSpriteFrameName("mod_badge_01_001.png");
+    }
+}
+
+class modCheck {
 public:
+    void DelayMod(CCObject* sender) {
+        auto scene = CCDirector::get()->getRunningScene();
+        CCObject* pObj = nullptr;
 
-	void DelayMod(CCObject* sender)
-	{
+        CCARRAY_FOREACH(static_cast<CCScene*>(scene)->getChildren(), pObj) {
+            if (instanceof<UploadActionPopup>(pObj)) {
+                auto check = static_cast<UploadActionPopup*>(pObj);
 
-		auto scene = CCDirector::get()->getRunningScene();
-	
+                if (Mod::get()->getSettingValue<int64_t>("modType") == 1) {
+                    check->showSuccessMessage("Success! Moderator access granted.");
+                }
+                if (Mod::get()->getSettingValue<int64_t>("modType") == 2) {
+                    check->showSuccessMessage("Success! Elder Moderator \n access granted.");
+                }
+            }
+        }
+    }
 
-		CCObject* pObj = nullptr;
+    void DelayRate(CCObject* sender) {
+        auto scene = CCDirector::get()->getRunningScene();
+        CCObject* pObj = nullptr;
 
-				CCARRAY_FOREACH(((CCScene*)(scene))->getChildren(), pObj) {
-
-					if (instanceof<UploadActionPopup>(pObj)) {
-
-						UploadActionPopup* Check = static_cast<UploadActionPopup*>(pObj);
-
-						if (Mod::get()->getSettingValue<int64_t>("modType") == 1)
-						{
-							Check->showSuccessMessage("Success! Moderator access granted.");
-						}
-						if (Mod::get()->getSettingValue<int64_t>("modType") == 2)
-						{
-							Check->showSuccessMessage("Success! Elder Moderator \n access granted.");
-						}
-					}
-				}
-			
-		
-		
-	}
-
-	void DelayRate(CCObject* sender)
-	{
-		auto scene = CCDirector::get()->getRunningScene();
-
-
-		CCObject* pObj = nullptr;
-
-		CCARRAY_FOREACH(((CCScene*)(scene))->getChildren(), pObj) {
-
-			if (instanceof<UploadActionPopup>(pObj)) {
-
-				UploadActionPopup* Check = static_cast<UploadActionPopup*>(pObj);
-				Check->showSuccessMessage("Rating submitted!");
-			}
-		}
-
-		
-		
-		
-	}
+        CCARRAY_FOREACH(static_cast<CCScene*>(scene)->getChildren(), pObj) {
+            if (instanceof<UploadActionPopup>(pObj)) {
+                auto check = static_cast<UploadActionPopup*>(pObj);
+                check->showSuccessMessage("Rating submitted!");
+            }
+        }
+    }
 };
 
 class $modify(SupportLayer) {
-	void onRequestAccess(CCObject* sender) {
-		auto GM = GameManager::sharedState();
+    void onRequestAccess(CCObject* sender) {
+        auto gm = GameManager::sharedState();
 
-		if (Mod::get()->getSettingValue<int64_t>("modType") == 3)
-		{
-			SupportLayer::onRequestAccess(sender);
-			GM->m_hasRP = 0;
-		}
-		else
-		{
-			UploadActionPopup* popup = UploadActionPopup::create(nullptr, "Loading...");
-			popup->show();
-			popup->runAction((CCSequence::create(
-				CCDelayTime::create(1),
-				CCCallFunc::create(this, callfunc_selector(modCheck::DelayMod)),
-				nullptr
-			)));
-				GM->m_hasRP = Mod::get()->getSettingValue<int64_t>("modType");
-		}
-	}	
+        if (Mod::get()->getSettingValue<int64_t>("modType") == 3) {
+            SupportLayer::onRequestAccess(sender);
+            gm->m_hasRP = 0;
+        }
+        else {
+            auto popup = UploadActionPopup::create(nullptr, "Loading...");
+            popup->show();
+            popup->runAction(CCSequence::create(
+                CCDelayTime::create(1),
+                CCCallFunc::create(this, callfunc_selector(modCheck::DelayMod)),
+                nullptr
+            ));
+            gm->m_hasRP = Mod::get()->getSettingValue<int64_t>("modType");
+        }
+    }
 };
 
-class $modify(ProfilePage)
-{
-	void loadPageFromUserInfo(GJUserScore* p0)
-	{
-		int type = Mod::get()->getSettingValue<int64_t>("modType");
-		if (this->m_ownProfile)
-		{
-			switch(type) {
-				case 1: p0->m_modBadge = type; break;
-				case 2: p0->m_modBadge = type; break;
-				case 3: p0->m_modBadge = type; break;
-			}
-		}
-		ProfilePage::loadPageFromUserInfo(p0);
-	}
+class $modify(ProfilePage) {
+    void getUserInfoFinished(GJUserScore* score) {
+        ProfilePage::getUserInfoFinished(score);
+
+        if (!score) return;
+        if (score->m_accountID != GJAccountManager::get()->m_accountID) return;
+
+        int type = Mod::get()->getSettingValue<int64_t>("modType");
+        auto badge = createBadgeSprite(type);
+        if (!badge) return;
+
+        badge->setID("fakegdmod-badge");
+        badge->setScale(0.6f);
+
+        if (!this->m_usernameLabel) return;
+
+        auto parent = this->m_usernameLabel->getParent();
+        if (!parent) return;
+
+        if (auto old = parent->getChildByID("fakegdmod-badge")) {
+            old->removeFromParent();
+        }
+
+        auto pos = this->m_usernameLabel->getPosition();
+        auto size = this->m_usernameLabel->getContentSize() * this->m_usernameLabel->getScale();
+        badge->setPosition({
+            pos.x - size.width / 2.f - badge->getContentSize().width * 0.6f / 2.f - 8.f,
+            pos.y
+        });
+        parent->addChild(badge, this->m_usernameLabel->getZOrder() + 1);
+    }
 };
 
-class $modify(RateStarsLayer)
-{
-	void onRate(CCObject* sender)
-	{
-		CCLayer* layer = static_cast<CCLayer*>(this->getChildren()->objectAtIndex(0));
+class $modify(RateStarsLayer) {
+    void onRate(CCObject* sender) {
+        auto layer = static_cast<CCLayer*>(this->getChildren()->objectAtIndex(0));
 
-		if (layer->getChildrenCount() == 3) {
-			UploadActionPopup* popup = UploadActionPopup::create(nullptr, "Sending rating...");
-			popup->show();
-			popup->runAction((CCSequence::create(
-				CCDelayTime::create(1),
-				CCCallFunc::create(this, callfunc_selector(modCheck::DelayRate)),
-				nullptr
-			)));
-		}
-		else {
-			RateStarsLayer::onRate(sender);
-		}
-	}
+        if (layer->getChildrenCount() == 3) {
+            auto popup = UploadActionPopup::create(nullptr, "Sending rating...");
+            popup->show();
+            popup->runAction(CCSequence::create(
+                CCDelayTime::create(1),
+                CCCallFunc::create(this, callfunc_selector(modCheck::DelayRate)),
+                nullptr
+            ));
+        }
+        else {
+            RateStarsLayer::onRate(sender);
+        }
+    }
 };
 
-class $modify(RateDemonLayer)
-{
-	void onRate(CCObject * sender)
-	{
-		UploadActionPopup* popup = UploadActionPopup::create(nullptr, "Sending rating...");
-		popup->show();
-		popup->runAction((CCSequence::create(
-			CCDelayTime::create(1),
-			CCCallFunc::create(this, callfunc_selector(modCheck::DelayRate)),
-			nullptr
-		)));
-	}
+class $modify(RateDemonLayer) {
+    void onRate(CCObject* sender) {
+        auto popup = UploadActionPopup::create(nullptr, "Sending rating...");
+        popup->show();
+        popup->runAction(CCSequence::create(
+            CCDelayTime::create(1),
+            CCCallFunc::create(this, callfunc_selector(modCheck::DelayRate)),
+            nullptr
+        ));
+    }
 };
 
-class $modify(LevelInfoLayer)
-{
-	void levelDeleteFailed(int a1)
-	{
-		auto scene = CCDirector::get()->getRunningScene();
-		auto obj = (FLAlertLayer*)scene->getChildren()->lastObject();
-		
-		
-		if (Mod::get()->getSettingValue<int64_t>("modType") == 1 || Mod::get()->getSettingValue<int64_t>("modType") == 2)
-		{
+class $modify(LevelInfoLayer) {
+    void levelDeleteFailed(int a1) {
+        auto scene = CCDirector::get()->getRunningScene();
+        auto obj = static_cast<FLAlertLayer*>(scene->getChildren()->lastObject());
+        (void)obj;
 
-			
+        if (Mod::get()->getSettingValue<int64_t>("modType") == 1 || Mod::get()->getSettingValue<int64_t>("modType") == 2) {
+            FLAlertLayer::create("Level Deleted", "The level has been removed from the server", "OK")->show();
 
-			FLAlertLayer::create("Level Deleted", "The level has been removed from the server", "OK")->show();
-			/*scene->removeChild(obj);*/
-
-			CCObject* pObj = nullptr;
-
-			CCARRAY_FOREACH(((LevelInfoLayer*)(this))->getChildren(), pObj) {
-
-				if (instanceof<LoadingCircle>(pObj)) {
-
-					LoadingCircle* loadingCircle = static_cast<LoadingCircle*>(pObj);
-
-					loadingCircle->setVisible(false);
-				}
-			}
-		}
-		else
-		{
-			LevelInfoLayer::levelDeleteFailed(a1);
-		}
-	}
+            CCObject* pObj = nullptr;
+            CCARRAY_FOREACH(static_cast<LevelInfoLayer*>(this)->getChildren(), pObj) {
+                if (instanceof<LoadingCircle>(pObj)) {
+                    auto loadingCircle = static_cast<LoadingCircle*>(pObj);
+                    loadingCircle->setVisible(false);
+                }
+            }
+        }
+        else {
+            LevelInfoLayer::levelDeleteFailed(a1);
+        }
+    }
 };


### PR DESCRIPTION
This updates FakeGDMod for Geometry Dash 2.2081 / Geode 5.4.1 on PC.

Changes:
- Fix CMake source setup for the updated build
- Update metadata for GD 2.2081 / Geode 5.4.1
- Fix moderator badge rendering by using current sprite names
- Anchor the profile badge to ProfilePage::m_usernameLabel for stable placement

Tested on:
- Windows PC
- Geometry Dash 2.2081
- Geode 5.4.1
